### PR TITLE
Prepare for v1.4.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,26 @@ The view automatically handles:
 - Velocity-based gesture recognition
 - Z-index management for proper layering
 
+### Important Note About onAppear
+
+Since CardDeckView is built on top of ZStack, **all cards' `onAppear` modifiers are called when the deck is first displayed**, not when individual cards become visible. This is the expected behavior for ZStack in SwiftUI.
+
+If you need to trigger actions when a specific card becomes visible, use the `stackPosition` binding instead:
+
+```swift
+CardDeckView {
+    ForEach(cards) { card in
+        CardView(card: card)
+            .tag(card.id)
+    }
+}
+.stackPosition(tag: $currentPosition)
+.onChange(of: currentPosition) { newPosition in
+    // Trigger actions when card position changes
+    handleCardAppeared(for: newPosition)
+}
+```
+
 ## Development
 
 ### Building

--- a/Sources/CardDeckView/Modifiers/StackCardBackground.swift
+++ b/Sources/CardDeckView/Modifiers/StackCardBackground.swift
@@ -23,7 +23,7 @@ struct StackCardBackgroundModifier<V: View>: ViewModifier {
 }
 
 extension View {
-    public func stackCardBackground<Content: View>(_ view: () -> Content) -> some View {
+    public func stackCardBackground<Content: View>(@ViewBuilder _ view: () -> Content) -> some View {
         modifier(StackCardBackgroundModifier(view: view()))
     }
 }


### PR DESCRIPTION
## Summary
- Improve documentation with important note about onAppear behavior with ZStack
- Add @ViewBuilder attribute to stackCardBackground modifier for better syntax
- Prepare codebase for v1.4.0 minor version release

## Test plan
- [ ] Verify existing functionality remains intact
- [ ] Test stackCardBackground modifier with @ViewBuilder syntax
- [ ] Review documentation changes

🤖 Generated with [Claude Code](https://claude.ai/code)